### PR TITLE
Allocate contiguous memory by 'mmap'

### DIFF
--- a/libvm68k/bits/vm68k/read_write_memory.h
+++ b/libvm68k/bits/vm68k/read_write_memory.h
@@ -34,13 +34,32 @@ namespace vm68k
         using byte_type = unsigned char;
 
     protected:
-        static std::unique_ptr<byte_type []> allocate(size_type size);
+        class _VM68K_PUBLIC bytes_delete
+        {
+        private:
+            size_t _length;
+
+        public:
+            explicit constexpr bytes_delete(const std::size_t length) noexcept
+            :
+                _length {length}
+            {
+                // Nothing more to do.
+            }
+
+        public:
+            void operator ()(byte_type *ptr) const;
+        };
+
+    protected:
+        static auto allocate_bytes(size_t size)
+            -> std::unique_ptr<byte_type [], bytes_delete>;
 
     private:
         const size_type _size;
 
     private:
-        std::unique_ptr<byte_type []> _data;
+        std::unique_ptr<byte_type [], bytes_delete> _bytes;
 
     public:
         explicit read_write_memory(size_type size);

--- a/libvm68k/bits/vm68k/read_write_memory.h
+++ b/libvm68k/bits/vm68k/read_write_memory.h
@@ -37,12 +37,12 @@ namespace vm68k
         class _VM68K_PUBLIC bytes_delete
         {
         private:
-            size_t _length;
+            size_t _size;
 
         public:
-            explicit constexpr bytes_delete(const std::size_t length) noexcept
+            explicit constexpr bytes_delete(const std::size_t size) noexcept
             :
-                _length {length}
+                _size {size}
             {
                 // Nothing more to do.
             }

--- a/libvm68k/read_write_memory.cpp
+++ b/libvm68k/read_write_memory.cpp
@@ -91,7 +91,7 @@ void read_write_memory::check_write_access(const mode, const address_type,
 
 void read_write_memory::bytes_delete::operator ()(byte_type *ptr) const
 {
-    if (munmap(ptr, _length) == -1) {
+    if (munmap(ptr, _size) == -1) {
         throw system_error(errno, generic_category(),
             "could not release the memory mapping");
     }

--- a/libvm68k/read_write_memory.cpp
+++ b/libvm68k/read_write_memory.cpp
@@ -91,5 +91,8 @@ void read_write_memory::check_write_access(const mode, const address_type,
 
 void read_write_memory::bytes_delete::operator ()(byte_type *ptr) const
 {
-    munmap(ptr, _length);
+    if (munmap(ptr, _length) == -1) {
+        throw system_error(errno, generic_category(),
+            "could not release the memory mapping");
+    }
 }

--- a/libvm68k/read_write_memory.cpp
+++ b/libvm68k/read_write_memory.cpp
@@ -23,10 +23,12 @@
 #include <bits/vm68k/read_write_memory.h>
 
 #include <sys/mman.h>
-#include <stdexcept>
+#include <system_error>
+#include <cerrno>
 
-using std::runtime_error;
+using std::generic_category;
 using std::size_t;
+using std::system_error;
 using std::unique_ptr;
 using namespace vm68k;
 
@@ -39,7 +41,8 @@ auto read_write_memory::allocate_bytes(const size_t size)
     auto ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (ptr == nullptr) {
-        throw runtime_error("could not get an anonymous memory mapping");
+        throw system_error(errno, generic_category(),
+            "could not get an anonymous memory mapping");
     }
     return {static_cast<byte_type *>(ptr), bytes_delete(size)};
 }


### PR DESCRIPTION
This pull request changes class `read_write_memory` to allocate its contiguous memory using `mmap`.